### PR TITLE
env(docker): add privilege and give container enough time to shutdown

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   nodeosd:
     image: eosio/eos-dev
-    command: /opt/eosio/bin/nodeosd.sh --data-dir /opt/eosio/bin/data-dir -e --replay-blockchain --hard-replay-blockchain
+    command: /opt/eosio/bin/nodeosd.sh --data-dir /opt/eosio/bin/data-dir -e # --replay-blockchain --hard-replay-blockchain
     hostname: nodeosd
     ports:
       - 8888:8888
@@ -15,6 +15,9 @@ services:
     environment:
       - VIRTUAL_HOST=local.eosio.cr
       - VIRTUAL_PORT=8888
+    cap_add:
+      - IPC_LOCK
+    stop_grace_period: 10m
     networks:
       eos-local:
         aliases:
@@ -28,6 +31,7 @@ services:
       - nodeosd
     volumes:
       - keosd-data-volume:/opt/eosio/bin/data-dir
+    stop_grace_period: 10m
     networks:
       eos-local:
 


### PR DESCRIPTION
- `stop_grace_period` gives nodeos enough time to shutdown gracefully, avoids the situation to run --hard-replay-blockchain;
- `IPC_LOCK` gives nodeos needed privilege to pin chainbase shared memory.

see https://github.com/EOSIO/eos/pull/4632